### PR TITLE
feat: include optional OIDC claims for profile matching

### DIFF
--- a/bin/chinmina_token
+++ b/bin/chinmina_token
@@ -6,6 +6,8 @@ url="$CHINMINA_TOKEN_LIBRARY_FUNCTION_CHINMINA_URL"
 audience="$CHINMINA_TOKEN_LIBRARY_FUNCTION_AUDIENCE"
 : "${TMPDIR:?TMPDIR environment variable required}"
 
+additional_oidc_claims="pipeline_id,cluster_id,cluster_name,queue_id,queue_key"
+
 # This script is responsible for getting a token for a given profile (or the default)
 profile_name=${1:-"default"}
 
@@ -18,7 +20,7 @@ if ! oidc_auth_token="$(cache_read "${BUILDKITE_JOB_ID}")"; then
   # timings are output to stderr, which Git ignores.
   TIMEFORMAT='[oidc = %2Rs]'
   time {
-    oidc_auth_token="$(buildkite-agent oidc request-token --claim pipeline_id --audience "${audience}")"
+    oidc_auth_token="$(buildkite-agent oidc request-token --claim "${additional_oidc_claims}" --audience "${audience}")"
   }
   cache_write "${BUILDKITE_JOB_ID}" "${oidc_auth_token}"
 fi

--- a/tests/chinmina_token.bats
+++ b/tests/chinmina_token.bats
@@ -71,7 +71,7 @@ teardown() {
   local profile="org:sample-profile"
 
   stub buildkite-agent \
-    "oidc request-token --claim pipeline_id --audience "default" : echo '${oidc_token}'"
+    "oidc request-token --claim "pipeline_id,cluster_id,cluster_name,queue_id,queue_key" --audience "default" : echo '${oidc_token}'"
 
   stub curl "echo '{\"profile\": \"profile-name\", \"organisationSlug\": \"org123\", \"token\": \"728282727\", \"expiry\": $(date +%s)}'"
 


### PR DESCRIPTION
## Purpose

Enable Chinmina's conditional profile support by including optional claims in the OIDC token. The plugin now requests additional claims (pipeline_id, cluster_id, cluster_name, queue_id, queue_key) from Buildkite's OIDC token endpoint, which allows profile configurations to use match expressions based on pipeline and cluster context. Without these claims, conditional profile matching expressions cannot evaluate and will fail to grant appropriate access.

## Context

- Chinmina Bridge PR introducing conditional profile support: https://github.com/chinmina/chinmina-bridge/pull/131
- Profile access control documentation: https://chinmina.github.io/guides/profile-access-control/#available-claims

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OIDC tokens now include additional claims — pipeline_id, cluster_id, cluster_name, queue_id, and queue_key — to provide richer authentication context.

* **Tests**
  * Updated token request tests to confirm the expanded set of OIDC claims are included in authentication requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->