### PR TITLE
fix: remove User-Agent header functionality

### DIFF
--- a/bin/chinmina_token
+++ b/bin/chinmina_token
@@ -52,12 +52,6 @@ else
   request_path="organization/token/${profile_name}"
 fi
 
-plugin_version=$(echo "${BUILDKITE_PLUGINS:-}" | jq -r '
-  [.[] | keys[0] | select(startswith("github.com/chinmina/chinmina-token-buildkite-plugin#")) | split("#")[1]]
-  | first
-  // "v.unknown"
-')
-
 # POST request to fetch token from Github App
 chinmina_response=$(curl --retry 3 --retry-delay 1 --retry-connrefused \
   --silent --show-error --fail \
@@ -66,7 +60,6 @@ chinmina_response=$(curl --retry 3 --retry-delay 1 --retry-connrefused \
   --header "Authorization: Bearer ${oidc_auth_token}" \
   --header "Content-Type: text/plain" \
   --header "Accept: application/json" \
-  --header "User-Agent: chinmina-token-buildkite-plugin/${plugin_version}" \
 )
 
 token_exists="$(echo "$chinmina_response" | jq 'has("token")')"

--- a/tests/chinmina_token.bats
+++ b/tests/chinmina_token.bats
@@ -141,23 +141,6 @@ teardown() {
   unstub buildkite-agent  # Verify redactor was actually called
 }
 
-@test "Extracts plugin version from BUILDKITE_PLUGINS for User-Agent" {
-  local profile="default"
-  export BUILDKITE_PLUGINS='[{"github.com/chinmina/chinmina-token-buildkite-plugin#v1.1.0":{"audience":"test","chinmina-url":"http://test"}}]'
-
-  stub buildkite-agent "redactor add : cat > /dev/null"
-  stub curl \
-    "--retry 3 --retry-delay 1 --retry-connrefused --silent --show-error --fail --request POST * --data * --header * --header * --header * --header 'User-Agent: chinmina-token-buildkite-plugin/v1.1.0' : echo '{\"profile\": \"${profile}\", \"organisationSlug\": \"org123\", \"token\": \"test-token\", \"expiry\": $(date +%s)}'"
-
-  run './bin/chinmina_token' $profile
-
-  assert_success
-  assert_output --partial "test-token"
-
-  unstub curl  # Verify curl was called with correct User-Agent
-  unstub buildkite-agent
-}
-
 @test "accepts URL and audience via positional arguments" {
   local profile="default"
   local url="http://positional-url"


### PR DESCRIPTION
## Purpose

Removes the custom User-Agent header and version extraction logic that fails when the plugin is installed as a Buildkite agent hook. The BUILDKITE_PLUGINS environment variable is not available in agent hook contexts, causing the version extraction to always fall back to "v.unknown" and defeating the purpose of version identification. Removing this non-functional telemetry simplifies the code.

## Context

- The User-Agent functionality was recently added but discovered to not work in agent hook installation mode
- Agent hooks don't have access to BUILDKITE_PLUGINS environment variable, which is required for version extraction
- This removes both the version extraction logic and the User-Agent header from the curl request to Chinmina Bridge
- Related test case also removed from the test suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined chinmina token request by removing User-Agent header.
  * Removed dynamic plugin version extraction logic.
  * Updated tests to reflect simplified token request behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->