### PR TITLE
feat: dynamic repository scoping for org token requests

### DIFF
--- a/bin/chinmina_token
+++ b/bin/chinmina_token
@@ -15,8 +15,27 @@ script_dir=$(dirname "${BASH_SOURCE[0]}")
 # A caller may override the URL and audience by passing them directly as
 # parameters.
 #
-# Usage: chinmina_token <profile> [url] [audience]
+# Usage: chinmina_token [--repository-scope=<repo>] <profile> [url] [audience]
 #
+repository_scope=""
+args=()
+for arg in "$@"; do
+  case "${arg}" in
+    --repository-scope=*)
+      repository_scope="${arg#--repository-scope=}"
+      ;;
+    *)
+      args+=("${arg}")
+      ;;
+  esac
+done
+set -- "${args[@]+"${args[@]}"}"
+
+if [[ -n "${repository_scope}" && ! "${repository_scope}" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+  echo "Error: invalid repository scope '${repository_scope}'. Must contain only alphanumeric characters, underscores, and hyphens." >&2
+  exit 1
+fi
+
 requested_profile=${1:-"pipeline:default"}
 url="${2:-${CHINMINA_TOKEN_LIBRARY_FUNCTION_CHINMINA_URL:-}}"
 audience="${3:-${CHINMINA_TOKEN_LIBRARY_FUNCTION_AUDIENCE:-chinmina:default}}"
@@ -66,14 +85,25 @@ fi
 # Determine request path based on prefix
 case "${profile_prefix}" in
   pipeline)
+    if [[ -n "${repository_scope}" ]]; then
+      echo "Error: --repository-scope is only supported for 'org:' profiles" >&2
+      exit 1
+    fi
     request_path="token/${profile_name}"
     ;;
   repo)
+    if [[ -n "${repository_scope}" ]]; then
+      echo "Error: --repository-scope is only supported for 'org:' profiles" >&2
+      exit 1
+    fi
     echo -e "\033[33mWarning: 'repo:' prefix is deprecated. Use 'pipeline:' instead. This will be removed in the next major version.\033[0m" >&2
     request_path="token/${profile_name}"
     ;;
   org)
     request_path="organization/token/${profile_name}"
+    if [[ -n "${repository_scope}" ]]; then
+      request_path="${request_path}?repository-scope=${repository_scope}"
+    fi
     ;;
   *)
     echo "Error: unrecognized profile prefix '${profile_prefix}'. Use 'pipeline:' or 'org:'." >&2

--- a/hooks/environment
+++ b/hooks/environment
@@ -22,6 +22,7 @@ plugin_read_list() {
 # 4. Built-in default (audience only: "chinmina:default")
 url="${BUILDKITE_PLUGIN_CHINMINA_TOKEN_CHINMINA_URL:-${CHINMINA_DEFAULT_URL:-${CHINMINA_TOKEN_LIBRARY_FUNCTION_CHINMINA_URL:-}}}"
 audience="${BUILDKITE_PLUGIN_CHINMINA_TOKEN_AUDIENCE:-${CHINMINA_DEFAULT_AUDIENCE:-${CHINMINA_TOKEN_LIBRARY_FUNCTION_AUDIENCE:-chinmina:default}}}"
+repo_scope="${BUILDKITE_PLUGIN_CHINMINA_TOKEN_REPOSITORY_SCOPE:-}"
 
 # Validate required configuration
 if [[ -z "$url" ]]; then
@@ -45,6 +46,11 @@ requested_environment_profiles="$(plugin_read_list BUILDKITE_PLUGIN_CHINMINA_TOK
 if [[ -n "$requested_environment_profiles" ]]; then
   echo "~~~ :chinmina: Requesting GitHub tokens via Chinmina"
 
+  scope_args=()
+  if [[ -n "${repo_scope}" ]]; then
+    scope_args+=("--repository-scope=${repo_scope}")
+  fi
+
   # Environment mode: process array and export tokens
   # Does NOT modify PATH - calls chinmina_token by full path
   while IFS='=' read -r var_name profile; do
@@ -64,8 +70,8 @@ if [[ -n "$requested_environment_profiles" ]]; then
       library_function="chinmina_token"
     fi
 
-    # Pass configuration via positional arguments
-    if ! token="$("$library_function" "$profile" "$url" "$audience")"; then
+    # Pass configuration via positional arguments, with optional repository scope
+    if ! token="$("$library_function" "$profile" "$url" "$audience" "${scope_args[@]+"${scope_args[@]}"}")"; then
       echo "Token retrieval failed for: '$profile'" >&2
       exit 1
     fi
@@ -74,7 +80,13 @@ if [[ -n "$requested_environment_profiles" ]]; then
     export "${var_name}=${token}"
   done <<<"${requested_environment_profiles}"
 else
-  # Library mode: export configuration and add to PATH for manual usage
+  # Library mode: repository-scope is incompatible (no target variables to scope to)
+  if [[ -n "${repo_scope}" ]]; then
+    echo "repository-scope is not supported in library mode; set the 'environment' plugin parameter to use repository scoping" >&2
+    exit 1
+  fi
+
+  # Export configuration and add to PATH for manual usage
   export CHINMINA_TOKEN_LIBRARY_FUNCTION_CHINMINA_URL="${url}"
   export CHINMINA_TOKEN_LIBRARY_FUNCTION_AUDIENCE="${audience}"
   export PATH="${PATH}:${library_function_path}"

--- a/hooks/environment
+++ b/hooks/environment
@@ -89,5 +89,5 @@ else
   # Export configuration and add to PATH for manual usage
   export CHINMINA_TOKEN_LIBRARY_FUNCTION_CHINMINA_URL="${url}"
   export CHINMINA_TOKEN_LIBRARY_FUNCTION_AUDIENCE="${audience}"
-  export PATH="${PATH}:${library_function_path}"
+  export PATH="${library_function_path}:${PATH}"
 fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -36,5 +36,14 @@ configuration:
         Array of environment variable assignments in the format 'VAR_NAME=org:profile'.
         Each entry exports an environment variable containing a token from the specified profile.
         When this parameter is present, the plugin operates in Environment Mode (PATH is not modified).
+    repository-scope:
+      type: string
+      description: |
+        The repository name (without owner prefix) to scope the token to. Only valid in
+        Environment Mode alongside `environment`. When set, each token request is narrowed
+        to this single repository. The profile in Chinmina Bridge must use
+        `{{caller-scoped-repository}}` for this to take effect.
+
+        Incompatible with Library Mode (no `environment` parameter).
   additionalProperties: false
   required: []

--- a/tests/chinmina_token.bats
+++ b/tests/chinmina_token.bats
@@ -320,3 +320,37 @@ teardown() {
 
   unstub buildkite-agent
 }
+
+@test "appends repository-scope as query parameter to org token request" {
+  # Custom curl stub that captures its full argument list
+  cat > "${STUB_BIN_DIR}/curl" << CURLSTUB
+#!/bin/bash
+echo "\$@" >> "${TMPDIR}/curl_invocation"
+echo '{"token": "scoped-hotel-token"}'
+CURLSTUB
+  chmod +x "${STUB_BIN_DIR}/curl"
+
+  stub buildkite-agent "redactor add : cat > /dev/null"
+
+  run './bin/chinmina_token' "--repository-scope=hotel" "org:agent-workflows"
+
+  assert_success
+  assert_output --partial "scoped-hotel-token"
+
+  run grep -q "organization/token/agent-workflows?repository-scope=hotel" "${TMPDIR}/curl_invocation"
+  assert_success
+}
+
+@test "rejects --repository-scope for non-org profiles" {
+  run './bin/chinmina_token' "--repository-scope=hotel" "pipeline:default"
+
+  assert_failure
+  assert_output --partial "Error: --repository-scope is only supported for 'org:' profiles"
+}
+
+@test "rejects --repository-scope with invalid characters" {
+  run './bin/chinmina_token' "--repository-scope=hotel&evil=1" "org:agent-workflows"
+
+  assert_failure
+  assert_output --partial "Error: invalid repository scope 'hotel&evil=1'"
+}

--- a/tests/environment.bats
+++ b/tests/environment.bats
@@ -390,3 +390,34 @@ run_environment() {
 
   unstub chinmina_token
 }
+
+@test "Environment mode: forwards repository-scope to each chinmina_token call" {
+  export BUILDKITE_PLUGIN_CHINMINA_TOKEN_CHINMINA_URL="test-url"
+  export BUILDKITE_PLUGIN_CHINMINA_TOKEN_AUDIENCE="test-audience"
+  export BUILDKITE_PLUGIN_CHINMINA_TOKEN_ENVIRONMENT_0="WRITE_TOKEN=org:agent-write"
+  export BUILDKITE_PLUGIN_CHINMINA_TOKEN_ENVIRONMENT_1="READ_TOKEN=org:agent-read"
+  export BUILDKITE_PLUGIN_CHINMINA_TOKEN_REPOSITORY_SCOPE="hotel"
+
+  stub chinmina_token \
+    "org:agent-write test-url test-audience --repository-scope=hotel : echo 'write-token'" \
+    "org:agent-read test-url test-audience --repository-scope=hotel : echo 'read-token'"
+
+  run_environment "$PWD/hooks/environment"
+
+  assert_success
+  assert_line 'WRITE_TOKEN=write-token'
+  assert_line 'READ_TOKEN=read-token'
+
+  unstub chinmina_token
+}
+
+
+@test "Library mode: fails when repository-scope is configured" {
+  export BUILDKITE_PLUGIN_CHINMINA_TOKEN_CHINMINA_URL="test-url"
+  export BUILDKITE_PLUGIN_CHINMINA_TOKEN_REPOSITORY_SCOPE="hotel"
+
+  run "$PWD/hooks/environment"
+
+  assert_failure
+  assert_output --partial "repository-scope"
+}


### PR DESCRIPTION
## Purpose

Enables a single Chinmina organization profile to serve token requests for any repository, with each token narrowed to the specific repository the caller names at request time.

Previously, scoping a token to a repository required a dedicated profile entry per target repo. For AI agent workflows running from a central pipeline against dozens or hundreds of different repositories, maintaining one profile per repo is operationally untenable — every new target requires a config update and a profile refresh cycle. The `{{caller-scoped-repository}}` profile type in Chinmina Bridge removes that constraint, but the plugin had no way to pass the repository name through. This PR adds that path.

Input is validated on the way in (alphanumeric, hyphens, underscores only) to prevent query parameter injection, and the feature is restricted to environment mode — attempting to use it in library mode fails fast with a clear error rather than silently issuing a broader-than-intended token.

## Context

- Chinmina Bridge PRD: [chinmina-bridge#246 — Dynamic Repository Scoping](https://github.com/chinmina/chinmina-bridge/issues/246) (plugin requirements: §10)
- Bridge-side implementation (profile schema, endpoint validation, caching) is a separate PR in chinmina-bridge
- This PR covers only the plugin surface: the `repository-scope` config parameter and its propagation to the CLI script